### PR TITLE
Graphite support added with country code and tested

### DIFF
--- a/lib/ring/sqa/analyzer.rb
+++ b/lib/ring/sqa/analyzer.rb
@@ -45,7 +45,7 @@ class SQA
 
     def graphite
       require_relative 'graphite'
-      Graphite.new
+      Graphite.new @nodes
     end
 
   end

--- a/lib/ring/sqa/graphite.rb
+++ b/lib/ring/sqa/graphite.rb
@@ -7,21 +7,27 @@ class SQA
     ROOT = "nlnog.ring_sqa.#{CFG.afi}"
 
     def add records
+      host = @hostname.split(".").first
+      node =  @nodes.all
       records.each do |record|
+        nodename = noderec = node[record.peer][:name].split(".").first
+        nodecc = noderec = node[record.peer][:cc].downcase
         hash = {
-         "#{ROOT}.#{record.peer}.state" => record.result
+         "#{ROOT}.#{host}.#{nodecc}.#{nodename}.state" => record.result
         }
-        if record.result == 'success'
-          hash["#{ROOT}.#{record.peer}.latency"] = record.latency
+        if record.result != 'no response'
+          hash["#{ROOT}.#{host}.#{nodecc}.#{nodename}.latency"] = record.latency
         end
         @client.metrics hash, record.time
       end
     end
 
     private
-
-    def initialize server=CFG.graphite
+    
+    def initialize nodes, server=CFG.graphite
       @client = GraphiteAPI.new graphite: server
+      @hostname = Ring::SQA::CFG.host.name
+      @nodes = nodes
     end
   end
 


### PR DESCRIPTION
I have done some changes to make the graphite support actually work
Also changed the path graphite uses so you have the following format:
- nlnog.ring-sqa.<v4|v6>.<source_node>.<country_dest_node>.<dest_node>.<latency|state>
- Latency is in uSec, so I use scale in graphite

Attached some screenshots of our Grafana dashboard using this SQA graphite data.


![screenshot_grafana_sqa_worldmap](https://user-images.githubusercontent.com/14363863/27653632-febf3492-5c3f-11e7-8a6f-eaf160687499.jpg)
![screenshot_grafana_sqa](https://user-images.githubusercontent.com/14363863/27653633-fec223d2-5c3f-11e7-8085-bb40d1df15ef.jpg)



