### PR TITLE
prevent ring-sqa from crashing when graphite is unavailable

### DIFF
--- a/lib/ring/sqa/graphite.rb
+++ b/lib/ring/sqa/graphite.rb
@@ -18,7 +18,11 @@ class SQA
         if record.result != 'no response'
           hash["#{ROOT}.#{host}.#{nodecc}.#{nodename}.latency"] = record.latency
         end
-        @client.metrics hash, record.time
+        begin
+          @client.metrics hash, record.time
+        rescue
+          Log.error "Failed to write metrics to Graphite."
+        end
       end
     end
 


### PR DESCRIPTION
add some error handling to make sure that the entire ring-sqa process does not crash when writing metrics to Graphite fails.