### PR TITLE
Add an extra header/body separator CRLF to ensure the first line of the body does not become part of the header

### DIFF
--- a/lib/ring/sqa/alarm/email.rb
+++ b/lib/ring/sqa/alarm/email.rb
@@ -34,7 +34,7 @@ class Alarm
       mail << 'X-Mailer: ' + 'ring-sqa'
       mail << ''
       mail = mail.join("\n")
-      mail+@body
+      mail+"\n"+@body
     end
 
     def send_email email


### PR DESCRIPTION
A very simple fix that likely went unnoticed for a while ;) Thanks for building this system @ytti and @job very cool and useful!


Add an extra header/body separator CRLF to ensure the first line of the body does not become part of the header

Funny that in both instances (set/clear) there was a single word before the ':', thus really making it look like a header ;)

Before for clearing the alarm:
```
List-Id: ring-sqa <sqa.ring.nlnog.net>
X-Mailer: ring-sqa
massar01.ring.nlnog.net: clearing ipv4 alarm
<Other headers added by spam systems etc>

<empty body>
```

Or for raising the alarm:
```
List-Id: ring-sqa <sqa.ring.nlnog.net>
X-Mailer: ring-sqa
Regarding: massar01.ring.nlnog.net ipv4
<anti-spam headers added by other systems>

This is an automated alert from the distributed partial outage
...
```

After this change:
```
List-Id: ring-sqa <sqa.ring.nlnog.net>
X-Mailer: ring-sqa
<anti-spam headers>

massar01.ring.nlnog.net: clearing ipv4 alarm
```

or for raising the alarm:
```
List-Id: ring-sqa <sqa.ring.nlnog.net>
X-Mailer: ring-sqa
<anti-spam headers added by other systems>

Regarding: massar01.ring.nlnog.net ipv4
This is an automated alert from the distributed partial outage
...
```