### PR TITLE
Fix missing empty line after headers

### DIFF
--- a/lib/ring/sqa/alarm/email.rb
+++ b/lib/ring/sqa/alarm/email.rb
@@ -16,15 +16,14 @@ class Alarm
       @list_id  = CFG.email.list_id? ? CFG.email.list_id : LIST_ID
       @subject  = prefix + short
       @reply_to = CFG.email.reply_to? ? CFG.email.reply_to : @from
-      @body     = long
-      send_email compose_email
+      send_email compose_email(long)
     rescue => error
       Log.error "Email raised '#{error.class}' with message '#{error.message}'"
     end
 
     private
 
-    def compose_email
+    def compose_email body
       mail = []
       mail << 'From: '     + @from
       mail << 'To: '       + @to.join(', ')
@@ -32,9 +31,8 @@ class Alarm
       mail << 'Subject: '  + @subject
       mail << 'List-Id: '  + @list_id
       mail << 'X-Mailer: ' + 'ring-sqa'
-      mail << ''
-      mail = mail.join("\n")
-      mail+@body
+      mail << '' << body
+      mail.join("\n")
     end
 
     def send_email email


### PR DESCRIPTION
Between email headers and body there wasnt empty line, but there was empty string in front of the body.