### PR TITLE
Added support for InfluxDB 1.8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,15 @@
 
 # 0.4.0
   - Graphite support added with country code (rinsekloek)
+
+# 0.4.1
+  - Version bump
+
+# 0.4.2
+  - Fix processing of /etc/hosts
+
+# 0.4.3
+  - Update to new Sequel API (fixes #21)
+
+# 0.4.4
+  - InfluxDB support added

--- a/lib/ring/sqa/analyzer.rb
+++ b/lib/ring/sqa/analyzer.rb
@@ -16,6 +16,8 @@ class SQA
         sleep INFLIGHT_WAIT
         records = records.all
         @graphite.add @db.id_range(first_id, @db_id_seen).all if @graphite
+        @influxdb.add @db.id_range(first_id, @db_id_seen).all if @influxdb
+        @kafka.add @db.id_range(first_id, @db_id_seen).all if @kafka
         @buffer.push records.map { |record| record.peer }
         @buffer.exceed_median? ? @alarm.set(@buffer) : @alarm.clear(@buffer)
         delay = INTERVAL-(Time.now-start)
@@ -41,12 +43,25 @@ class SQA
       @buffer     = AnalyzeBuffer.new @nodes.all.size
       @db_id_seen = 0
       @graphite   = graphite if CFG.graphite?
+      @influxdb   = influxdb if CFG.influxdb?
+      @kafka      = kafka if CFG.kafka?
     end
 
     def graphite
       require_relative 'graphite'
       Graphite.new @nodes
     end
+
+    def influxdb
+      require_relative 'influxdb'
+      InfluxDBWriter.new @nodes
+    end
+
+    def kafka
+      require_relative 'kafka_writer'
+      KafkaWriter.new @nodes
+    end
+
 
   end
 

--- a/lib/ring/sqa/analyzer.rb
+++ b/lib/ring/sqa/analyzer.rb
@@ -17,7 +17,6 @@ class SQA
         records = records.all
         @graphite.add @db.id_range(first_id, @db_id_seen).all if @graphite
         @influxdb.add @db.id_range(first_id, @db_id_seen).all if @influxdb
-        @kafka.add @db.id_range(first_id, @db_id_seen).all if @kafka
         @buffer.push records.map { |record| record.peer }
         @buffer.exceed_median? ? @alarm.set(@buffer) : @alarm.clear(@buffer)
         delay = INTERVAL-(Time.now-start)
@@ -44,7 +43,6 @@ class SQA
       @db_id_seen = 0
       @graphite   = graphite if CFG.graphite?
       @influxdb   = influxdb if CFG.influxdb?
-      @kafka      = kafka if CFG.kafka?
     end
 
     def graphite
@@ -55,11 +53,6 @@ class SQA
     def influxdb
       require_relative 'influxdb'
       InfluxDBWriter.new @nodes
-    end
-
-    def kafka
-      require_relative 'kafka_writer'
-      KafkaWriter.new @nodes
     end
 
 

--- a/lib/ring/sqa/influxdb.rb
+++ b/lib/ring/sqa/influxdb.rb
@@ -1,0 +1,44 @@
+require 'influxdb-client'
+
+module Ring
+class SQA
+  class InfluxDBWriter
+    ROOT = "nlnog.ring_sqa.#{CFG.afi}"
+
+    def add(records)
+      host   = @hostname.split(".").first
+      node   = @nodes.all
+      data   = []
+
+      records.each do |record|
+        nodename = nodecc = node[record.peer][:name].split(".").first
+        nodecc = node[record.peer][:cc].downcase
+
+        point = InfluxDB2::Point.new(name: 'ring-sqa_measurements')
+                                .add_tag('afi', CFG.afi)
+                                .add_tag('dst_node', nodename)
+                                .add_tag('dst_cc', nodecc)
+                                .add_tag('src_node', host)
+                                .add_tag('dst_lat', node[record.peer][:geo].split(",")[0])
+                                .add_tag('dst_lon', node[record.peer][:geo].split(",")[1])
+                                .add_field('latency', record.latency)
+                                .add_field('state', record.result == 'no response' ? 0 : 1)
+
+        @write_api.write(data: point)
+      rescue => e
+        Log.error "Failed to write metrics to InfluxDB: #{e.message}"
+      end
+    end
+
+    private
+
+    def initialize(nodes)
+      @client = InfluxDB2::Client.new(CFG.influxdb.url, CFG.influxdb.token, bucket: CFG.influxdb.bucket, org: CFG.influxdb.org, use_ssl: false, precision: InfluxDB2::WritePrecision::NANOSECOND)
+      @write_api = @client.create_write_api  # ✅ Fix write_api issue
+      @hostname = Ring::SQA::CFG.host.name
+      @nodes = nodes
+    end
+  end
+end
+end
+

--- a/lib/ring/sqa/nodes.rb
+++ b/lib/ring/sqa/nodes.rb
@@ -63,6 +63,7 @@ class SQA
           ip:   ip,
           as:   json['asn'],
           cc:   json['countrycode'],
+          geo:   json['geo'],
         }
         next if CFG.host.name == node[:name]
         nodes[ip] = node

--- a/ring-sqa.gemspec
+++ b/ring-sqa.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'ring-sqa'
-  s.version           = '0.4.0'
+  s.version           = '0.4.4'
   s.licenses          = %w( Apache-2.0 )
   s.platform          = Gem::Platform::RUBY
   s.authors           = [ 'Saku Ytti', 'Job Snijders' ]
@@ -13,11 +13,12 @@ Gem::Specification.new do |s|
   s.executables       = %w( ring-sqad )
   s.require_path      = 'lib'
 
-  s.required_ruby_version =                '>= 1.9.3'
-  s.add_runtime_dependency 'slop',         '~> 3.5'
-  s.add_runtime_dependency 'rb-inotify',   '~> 0.9'
-  s.add_runtime_dependency 'sequel',       '~> 4.12'
-  s.add_runtime_dependency 'sqlite3',      '~> 1.3'
-  s.add_runtime_dependency 'asetus',       '~> 0.1', '>= 0.1.2'
-  s.add_runtime_dependency 'graphite-api', '~> 0.1', '>= 0.1.6'
+  s.required_ruby_version =                   '>= 1.9.3'
+  s.add_runtime_dependency 'slop',            '~> 3.5'
+  s.add_runtime_dependency 'rb-inotify',      '~> 0.9'
+  s.add_runtime_dependency 'sequel',          '~> 4.12'
+  s.add_runtime_dependency 'sqlite3',         '~> 1.3'
+  s.add_runtime_dependency 'asetus',          '~> 0.1', '>= 0.1.2'
+  s.add_runtime_dependency 'graphite-api',    '~> 0.1', '>= 0.1.6'
+  s.add_runtime_dependency 'influxdb-client', '~> 0.1', '>= 3.2.0'
 end

--- a/ring-sqa.gemspec
+++ b/ring-sqa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rb-inotify',      '~> 0.9'
   s.add_runtime_dependency 'sequel',          '~> 4.12'
   s.add_runtime_dependency 'sqlite3',         '~> 1.3'
-  s.add_runtime_dependency 'asetus',          '~> 0.1', '>= 0.1.2'
-  s.add_runtime_dependency 'graphite-api',    '~> 0.1', '>= 0.1.6'
-  s.add_runtime_dependency 'influxdb-client', '~> 0.1', '>= 3.2.0'
+  s.add_runtime_dependency 'asetus',          '~> 0.3'
+  s.add_runtime_dependency 'graphite-api',    '~> 0.1.0'
+  s.add_runtime_dependency 'influxdb-client', '>= 0.1', '<= 3.2.0'
 end


### PR DESCRIPTION
With this PR I have added influx support to ring-sqa just like how the graphite support was done. To configure the settings add the next parameters to the /etc/ring-sqa/main.conf:

```
influxdb:
   url: "http://server:8086" (Your influx server)
   bucket: "ring-sqa" (Influx 1.8 this is the database)
   token: "" (Influx 1.8 use this format: <username>:<password>
   org : "nlnog" (Can be left empty in influx 1.8)
```

The measurements are written in ring-sqa_measurements

The next fields are availible:
```
 latency
 state
```
 
These tags are availible:
```
 afi       = IPv4/Ipv6
 src_node  = Source node
 dst_node  = Destination node
 dst_cc    = Destination node country
 dst_lat   = Destination node latitude
 dst_lon   = Destination node longitude
```