### PR TITLE
Graphite: Set state to 0 when result is 'no response'

### DIFF
--- a/lib/ring/sqa/graphite.rb
+++ b/lib/ring/sqa/graphite.rb
@@ -12,10 +12,12 @@ class SQA
       records.each do |record|
         nodename = noderec = node[record.peer][:name].split(".").first
         nodecc = noderec = node[record.peer][:cc].downcase
-        hash = {
-         "#{ROOT}.#{host}.#{nodecc}.#{nodename}.state" => record.result
-        }
-        if record.result != 'no response'
+        hash = {}
+
+        if record.result == 'no response'
+          hash["#{ROOT}.#{host}.#{nodecc}.#{nodename}.state"] = 0
+        else
+          hash["#{ROOT}.#{host}.#{nodecc}.#{nodename}.state"] = 1
           hash["#{ROOT}.#{host}.#{nodecc}.#{nodename}.latency"] = record.latency
         end
         begin


### PR DESCRIPTION
This brings the behaviour in line with the InfluxDB logic.

Additionally: shouldn't specifically check for `result == 'ok'`? Looking at the code, the possible values are:

* `ok`
* `connection refused`
* `network unreachable`
* `no response` (the default)

It looks to me that the host is only 'up' when the result is `ok`.